### PR TITLE
Add setup.py and requirements.txt to make it a pip package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+termcolor
+tb-nightly
+imageio
+imageio-ffmpeg
+hydra-core
+dm_control @ git+https://github.com/deepmind/dm_control.git
+dmc2gym @ git+https://github.com/denisyarats/dmc2gym.git

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,20 @@
+import re
+from setuptools import setup, find_packages
+
+install_requires = [line.rstrip() for line in open("requirements.txt", "r")]
+
+with open("README.md", "r") as f:
+    long_description = f.read()
+
+setup(
+    name="pytorch_sac",
+    version="0.0.1",
+    author="Denis Yarats",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/denisyarats/pytorch_sac",
+    packages=find_packages(),
+    install_requires=install_requires,
+    include_package_data=True,
+    zip_safe=False,
+)


### PR DESCRIPTION
Hi @luisenp,

I would like to add `setup.py` and `requirements.txt` to make this repo a pip package.

With this change, users will be able to install this by either `pip install git+https://github.com/luisenp/pytorch_sac` or `pip install -e .`